### PR TITLE
temperature-pressure MS plotting

### DIFF
--- a/development_scripts/reader_testers/test_ixdat_reader_TMS.py
+++ b/development_scripts/reader_testers/test_ixdat_reader_TMS.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+from ixdat import Measurement
+
+data_dir = Path("~/Dropbox/ixdat_resources/test_data/cinfdata/Krabbe").expanduser()
+
+tms = Measurement.read(
+    data_dir / "baratron_temp_measurement.txt.csv",
+    reader="ixdat",
+    technique="reactor",
+)
+
+tms.plot()

--- a/development_scripts/reader_testers/test_ixdat_reader_TPMS.py
+++ b/development_scripts/reader_testers/test_ixdat_reader_TPMS.py
@@ -3,10 +3,11 @@ from ixdat import Measurement
 
 data_dir = Path("~/Dropbox/ixdat_resources/test_data/cinfdata/Krabbe").expanduser()
 
-tms = Measurement.read(
+tpms = Measurement.read(
     data_dir / "baratron_temp_measurement.txt.csv",
     reader="ixdat",
     technique="reactor",
+    aliases={"pressure": ["Reactor pressure"], "temperature": ["TC temperature"]},
 )
 
-tms.plot()
+tpms.plot()

--- a/development_scripts/reader_testers/test_ixdat_reader_TPMS.py
+++ b/development_scripts/reader_testers/test_ixdat_reader_TPMS.py
@@ -10,4 +10,6 @@ tpms = Measurement.read(
     aliases={"pressure": ["Reactor pressure"], "temperature": ["TC temperature"]},
 )
 
-tpms.plot()
+axes = tpms.plot()
+
+axes[0].get_figure().savefig("tpms_plot.png")

--- a/src/ixdat/plotters/tpms_plotter.py
+++ b/src/ixdat/plotters/tpms_plotter.py
@@ -136,3 +136,5 @@ class TPMSPlotter(MPLPlotter):
         axes[3].set_xlabel("time / [s]")
         axes[3].set_ylabel(P_name)
         color_axis(axes[3], P_color)
+
+        return axes

--- a/src/ixdat/plotters/tpms_plotter.py
+++ b/src/ixdat/plotters/tpms_plotter.py
@@ -1,0 +1,138 @@
+from .base_mpl_plotter import MPLPlotter
+from .ms_plotter import MSPlotter
+from .plotting_tools import color_axis
+
+
+class TPMSPlotter(MPLPlotter):
+    """A matplotlib plotter for EC-MS measurements."""
+
+    def __init__(self, measurement=None):
+        """Initiate the ECMSPlotter with its default Measurement to plot"""
+        self.measurement = measurement
+        self.ms_plotter = MSPlotter(measurement=measurement)
+
+    def plot_measurement(
+        self,
+        *,
+        measurement=None,
+        axes=None,
+        mass_list=None,
+        mass_lists=None,
+        mol_list=None,
+        mol_lists=None,
+        tspan=None,
+        tspan_bg=None,
+        remove_background=None,
+        unit=None,
+        T_name=None,
+        P_name=None,
+        T_color="k",
+        P_color="r",
+        logplot=None,
+        legend=True,
+        emphasis="top",
+        **kwargs,
+    ):
+        """Make an EC-MS plot vs time and return the axis handles.
+
+        Allocates tasks to ECPlotter.plot_measurement() and MSPlotter.plot_measurement()
+
+        Args:
+            measurement (ECMSMeasurement): Defaults to the measurement to which the
+                plotter is bound (self.measurement)
+            axes (list of three matplotlib axes): axes[0] plots the MID data,
+                axes[1] the variable given by V_str (potential), and axes[2] the
+                variable given by J_str (current). By default three axes are made with
+                axes[0] a top panel with 3/5 the area, and axes[1] and axes[2] are
+                the left and right y-axes of the lower panel with 2/5 the area.
+            mass_list (list of str): The names of the m/z values, eg. ["M2", ...] to
+                plot. Defaults to all of them (measurement.mass_list)
+            mass_lists (list of list of str): Alternately, two lists can be given for
+                masses in which case one list is plotted on the left y-axis and the other
+                on the right y-axis of the top panel.
+            mol_list (list of str): The names of the molecules, eg. ["H2", ...] to
+                plot. Defaults to all of them (measurement.mass_list)
+            mol_lists (list of list of str): Alternately, two lists can be given for
+                molecules in which case one list is plotted on the left y-axis and the
+                other on the right y-axis of the top panel.
+            tspan (iter of float): The time interval to plot, wrt measurement.tstamp
+            tspan_bg (timespan): A timespan for which to assume the signal is at its
+                background. The average signals during this timespan are subtracted.
+                If `mass_lists` are given rather than a single `mass_list`, `tspan_bg`
+                must also be two timespans - one for each axis. Default is `None` for no
+                background subtraction.
+            remove_background (bool): Whether otherwise to subtract pre-determined
+                background signals if available. Defaults to (not logplot)
+            unit (str): the unit for the MS data. Defaults to "A" for Ampere
+            T_name (str): The name of the value to plot on the lower left y-axis.
+                Defaults to the name of the series `measurement.potential`
+            P_name (str): The name of the value to plot on the lower right y-axis.
+                Defaults to the name of the series `measurement.current`
+            T_color (str): The color to plot the variable given by 'V_str'
+            P_color (str): The color to plot the variable given by 'J_str'
+            logplot (bool): Whether to plot the MS data on a log scale (default True
+                unless mass_lists are given)
+            legend (bool): Whether to use a legend for the MS data (default True)
+            emphasis (str or None): "top" for bigger top panel, "bottom" for bigger
+                bottom panel, None for equal-sized panels
+            kwargs (dict): Additional kwargs go to all calls of matplotlib's plot()
+
+        Returns:
+            list of Axes: (top_left, bottom_left, top_right, bottom_right) where:
+                axes[0] is top_left is MS data;
+                axes[1] is bottom_left is potential;
+                axes[2] is top_right is additional MS data if left and right mass_lists
+                    or mol_lists were plotted (otherwise axes[2] is None); and
+                axes[3] is bottom_right is current.
+        """
+
+        if logplot is None:
+            logplot = not mol_lists and not mass_lists
+
+        if not axes:
+            axes = self.new_two_panel_axes(
+                n_bottom=2,
+                n_top=(2 if (mass_lists or mol_lists) else 1),
+                emphasis=emphasis,
+            )
+
+        measurement = measurement or self.measurement
+
+        if (
+            mass_list
+            or mass_lists
+            or mol_list
+            or mol_lists
+            or hasattr(measurement, "mass_list")
+        ):
+            # then we have MS data!
+            self.ms_plotter.plot_measurement(
+                measurement=measurement,
+                ax=axes[0],
+                axes=[axes[0], axes[2]] if (mass_lists or mol_lists) else axes[0],
+                tspan=tspan,
+                tspan_bg=tspan_bg,
+                remove_background=remove_background,
+                mass_list=mass_list,
+                mass_lists=mass_lists,
+                mol_list=mol_list,
+                mol_lists=mol_lists,
+                unit=unit,
+                logplot=logplot,
+                legend=legend,
+                **kwargs,
+            )
+
+        T_name = T_name or measurement.T_name
+        P_name = P_name or measurement.P_name
+
+        t_T, T = measurement.grab(T_name, tspan=tspan)
+        axes[1].plot(t_T, T, color=T_color)
+        axes[1].set_xlabel("time / [s]")
+        axes[1].set_ylabel(T_name)
+
+        t_P, P = measurement.grab(P_name, tspan=tspan)
+        axes[3].plot(t_P, P, color=P_color)
+        axes[3].set_xlabel("time / [s]")
+        axes[3].set_ylabel(P_name)
+        color_axis(axes[3], P_color)

--- a/src/ixdat/techniques/__init__.py
+++ b/src/ixdat/techniques/__init__.py
@@ -11,6 +11,7 @@ from .ec import ECMeasurement, ECCalibration
 from .cv import CyclicVoltammogram
 from .ms import MSMeasurement, MSCalibration
 from .ec_ms import ECMSMeasurement, ECMSCalibration
+from .reactor import ReactorMeasurement
 from .spectroelectrochemistry import SpectroECMeasurement
 from ..measurements import Measurement  # for importing in the technique modules
 
@@ -23,6 +24,7 @@ TECHNIQUE_CLASSES = {
     "MS": MSMeasurement,
     "EC-MS": ECMSMeasurement,
     "S-EC": SpectroECMeasurement,
+    "reactor": ReactorMeasurement,
 }
 
 CALIBRATION_CLASSES = {

--- a/src/ixdat/techniques/reactor.py
+++ b/src/ixdat/techniques/reactor.py
@@ -1,0 +1,5 @@
+from .ms import MSMeasurement
+
+
+class ReactorMeasurement(MSMeasurement):
+    pass

--- a/src/ixdat/techniques/reactor.py
+++ b/src/ixdat/techniques/reactor.py
@@ -1,5 +1,34 @@
+from abc import ABC
+
 from .ms import MSMeasurement
+from ..plotters.tpms_plotter import TPMSPlotter
 
 
 class ReactorMeasurement(MSMeasurement):
-    pass
+
+    default_plotter = TPMSPlotter
+    essential_series_names = ("temperature", "pressure")
+
+    @property
+    def T_name(self):
+        return self["temperature"].name
+
+    @property
+    def P_name(self):
+        return self["pressure"].name
+
+    @property
+    def t_name(self):
+        return self["temperature"].tseries.name
+
+    @property
+    def T(self):
+        return self["temperature"].data
+
+    @property
+    def P(self):
+        return self["pressure"].data
+
+    @property
+    def t(self):
+        return self["temperature"].t


### PR DESCRIPTION
Hi @AlexanderKrabbe ,

This PR creates a new Measurement class called `ReactorMeasurement` which inherits from `MSMeasurement` and adds to that the essential series `Temperature` and `Pressure`. It makes plots like ixdat's EC-MS plots, but with temperature taking the place of potential and pressure taking the place of current. 

The `ReactorMeasurement` class would be a great place to add all kinds of cool methods, like calculating conversion as a function of temperature, etc. Just like for a `MSMeasurement`, you can get MS sensitivity factors with `MSInlet.gas_flux_calibration` and then add them to your `ReactorMeasurement` using `my_reactor_meas.calibrate(ms_cal_results=[my_cal_H2_M2, ...])`

You will need to specify the `technique` and `aliases` for pressure and temperature when reading TPMS data with `reader="cinfdata"` or `"ixdat"`. An example is given in **test_ixdat_reader_TPMS** using the example data you sent me. You will need to change data_dir but otherwise should run. Let me know if it works!
